### PR TITLE
chore: specify linux/amd64 platform for mailhog container

### DIFF
--- a/dc-local.yml
+++ b/dc-local.yml
@@ -105,6 +105,7 @@ services:
       - redis
 
   mailhog:
+    platform: linux/amd64
     image: mailhog/mailhog:latest
     container_name: mailhog
     profiles:


### PR DESCRIPTION
## Ticket

<!-- Link to the Jira ticket -->

## What did I do

<!-- Fill with more infos if needed -->
